### PR TITLE
Feature - site customisations

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 
   {% include head.html %}
 
-  <body class="layout-reverse sidebar-overlay theme-pusto">
+  <body class="sidebar-overlay theme-pusto">
 
     {% include sidebar.html %}
 

--- a/_layouts/page-with-latest.html
+++ b/_layouts/page-with-latest.html
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+
+<div class="page">
+
+  <aside class="alternate-page-template__aside">
+    <img src="{{site.url | append: page.feature_image }}" class="alternate-page-template__feature-image">
+    <h3>Contact</h3>
+    <a href="mailto:{{ page.contact_email }}">{{ page.contact_email }}</a>
+  </aside>
+
+  {{ content }}
+
+  <hr>
+  <h2>Latest Posts</h2>
+  <hr>
+  <div class="posts alternate-page-template__posts">
+    {% for post in site.posts limit:5%}
+    <div class="post">
+      <h3 class="post-title">
+        <a href="{{ site.baseurl }}/{{ post.url }}">
+          {{ post.title }}
+        </a>
+      </h1>
+
+      <span class="post-date">
+        {{ post.date | date_to_string }}
+        {% if post.tags != empty %}
+        |
+        {% for tag in post.tags %}
+        <a class="codinfox-tag-mark" href="/tags/#{{ tag | slugify }}">{{ tag }}</a>
+        {% endfor %}
+        {% endif %}
+      </span>
+
+      <p>{{ post.excerpt | remove: '<p>' | remove: '</p>' | truncatewords: 35 }}</p>
+      <a href="{{ site.baseurl }}/{{ post.url }}">Full Post...</a>
+    </div>
+    {% endfor %}
+  </div>
+
+</div>

--- a/about.md
+++ b/about.md
@@ -1,13 +1,10 @@
 ---
-layout: page
+layout: page-with-latest
 title: About
 permalink: /about/
+feature_image: /images/James_headshot.jpg
+contact_email: pusto@austin.utexas.edu
 ---
-
-  
-<img src="{{site.url}}/images/James_headshot.jpg" width="350" style="float:right; margin-bottom:-5px">
-
-### James E. Pustejovsky
 
 Assistant Professor  
 [Quantitative Methods program](http://www.edb.utexas.edu/education/departments/edp/doctoral/qm/)  
@@ -18,10 +15,6 @@ Assistant Professor
 ### Curriculum Vitae
 
 [Curriculum Vitae]({{ site.url }}/files/Pustejovsky_CV.pdf)
-
-### Contact
-
-[pusto@austin.utexas.edu](mailto:pusto@austin.utexas.edu)
 
 ### Mailing address:
 

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -64,6 +64,13 @@ h1, h2, h3, h4, h5, h6 {
   position: relative;
   width: 100%;
 }
+/*  Allow sidebar space to remain fixed in place on desktop screen sizes */
+@media (min-width: 50em) {
+  .wrap {
+    width: 80%;
+    margin-left: 20%;
+  }
+}
 
 
 /*
@@ -160,6 +167,14 @@ h1, h2, h3, h4, h5, h6 {
     font-size: .75rem; /* 14px */
   }
 }
+/* Fix sidebar on lefthand side of screen above 50em(800px) */
+@media (min-width: 50em) {
+  .sidebar {
+    width: 20%;
+    visibility: visible;
+    left: 0;
+  }
+}
 
 /* Sidebar content */
 .sidebar a {
@@ -216,6 +231,13 @@ a.sidebar-nav-item:focus {
   background-color: #fff;
   border-radius: .25rem;
   cursor: pointer;
+}
+/*  Fixing the sidebar in place no longer requires the toggle on desktop screen sizes, hide above 50em */
+@media (min-width: 50em) {
+  .sidebar-toggle {
+    display: none;
+    visibility: hidden;
+  }
 }
 
 .sidebar-toggle:before {

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -591,3 +591,17 @@ a.pagination-item:hover {
 .layout-reverse.sidebar-overlay #sidebar-checkbox:checked ~ .sidebar {
   box-shadow: -.25rem 0 .5rem rgba(0,0,0,.1);
 }
+
+
+/*
+ * Pre Code overflow
+ *
+ * Code should never be broken onto multiple lines unless excplicity written
+ * as such. Code will scroll left/right as required to improve readability
+ *
+ */
+
+ pre {
+   overflow-x: scroll;
+   white-space: pre;
+ }

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -605,3 +605,48 @@ a.pagination-item:hover {
    overflow-x: scroll;
    white-space: pre;
  }
+
+ /*
+  * Style Alternate page template - used for About page
+  *
+  * Standard content blog allows text to be added via the markdown page.
+  * Image, contact email controled via front-matter and floated to the right
+  * on larger screen sizes
+  *
+  */
+
+.alternate-page-template__aside {
+  margin-bottom: 20px;
+
+}
+@media (min-width: 40em) {
+  .alternate-page-template__aside {
+    max-width: 50%;
+    float: right;
+    margin-left: 10px;
+    margin-bottom: 0;
+
+  }
+}
+
+@media (min-width: 50em) {
+  .alternate-page-template__aside  {
+    max-width: 40%;
+  }
+}
+
+.alternate-page-template__feature-image {
+  max-width: 60%;
+}
+@media (min-width: 40em) {
+  .alternate-page-template__feature-image {
+    max-width: 100%;
+  }
+}
+
+.alternate-page-template__posts {
+  font-size: 0.9em;
+}
+.alternate-page-template__posts .post {
+  margin-bottom: 2em;
+}


### PR DESCRIPTION
This pull request contains the following updates -

- [x] Fix sidebar on left-hand side on desktop, keep slide out sidebar on mobile. 
- [x] Lines within syntax highlighted code blocks should not break. Lines now scroll horizontally when required
- [x] New Page layout to replace about page showing Image/info and latest posts (5 most recent)

See screenshots below for reference -

<img width="1435" alt="screen shot 2016-08-27 at 13 18 10" src="https://cloud.githubusercontent.com/assets/2798285/18027344/3185030c-6c59-11e6-9a8b-ebf114f27353.png">
<img width="399" alt="screen shot 2016-08-27 at 13 20 16" src="https://cloud.githubusercontent.com/assets/2798285/18027345/31884f76-6c59-11e6-83ee-4f4c5e5a4af6.png">
<img width="551" alt="screen shot 2016-08-27 at 13 24 05" src="https://cloud.githubusercontent.com/assets/2798285/18027364/9496ca02-6c59-11e6-8654-0e0e440c8a74.png">

