### PR TITLE
add jekyll paginate to config 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ url:                 http://jepusto.github.io
 baseurl:             'http://jepusto.github.io'
 paginate:            10
 
+gems: [jekyll-paginate]
+
 # About/contact
 author:
   name:              James E. Pustejovsky


### PR DESCRIPTION
unless paginate gem is installed locally already site will produce warnings and will not display posts. This might trip people up working on the site in future. 

Error when running `jekyll serve` and black homepage.
<img width="749" alt="screen shot 2016-08-27 at 13 31 24" src="https://cloud.githubusercontent.com/assets/2798285/18027409/b6f52d2c-6c5a-11e6-9537-297ed0af9e6e.png">
<img width="995" alt="screen shot 2016-08-27 at 13 31 56" src="https://cloud.githubusercontent.com/assets/2798285/18027408/b6f173d0-6c5a-11e6-880f-afdc441d3031.png">
